### PR TITLE
Feat: persisted active profile + onboarding logic

### DIFF
--- a/LatchFit/ActiveProfileStore.swift
+++ b/LatchFit/ActiveProfileStore.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+final class ActiveProfileStore: ObservableObject {
+    @AppStorage("activeProfileID") var activeProfileID: String?
+
+    func setActive(_ id: String) {
+        activeProfileID = id
+        objectWillChange.send()
+    }
+}
+

--- a/LatchFit/LatchFitApp.swift
+++ b/LatchFit/LatchFitApp.swift
@@ -7,6 +7,7 @@ struct LatchFitApp: App {
 
     // Runtime feature switches (make sure FeatureFlags.swift exists with this class)
     @StateObject private var flags = FeatureFlags()
+    @StateObject private var activeProfileStore = ActiveProfileStore()
 
     #if DEBUG
     @State private var showDebugFlags = false
@@ -16,6 +17,7 @@ struct LatchFitApp: App {
         WindowGroup {
             ContentView()
                 .environmentObject(flags)
+                .environmentObject(activeProfileStore)
             #if DEBUG
                 .modifier(DebugPanelTrigger(showSheet: $showDebugFlags))
                 .sheet(isPresented: $showDebugFlags) {

--- a/LatchFit/ProfilesManagerView.swift
+++ b/LatchFit/ProfilesManagerView.swift
@@ -3,17 +3,25 @@ import SwiftData
 
 struct ProfilesManagerView: View {
     @Environment(\.modelContext) private var context
+    @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var activeProfileStore: ActiveProfileStore
     @Query(sort: [SortDescriptor(\MomProfile.createdAt, order: .reverse)]) private var profiles: [MomProfile]
 
     var body: some View {
         NavigationStack {
             List {
                 ForEach(profiles) { p in
-                    VStack(alignment: .leading) {
-                        Text(p.momName).font(.headline)
-                        Text("\(p.numberOfChildren) children • \(p.activityLevel)")
-                            .foregroundStyle(.secondary)
+                    Button {
+                        activeProfileStore.setActive(p.id.uuidString)
+                        dismiss()
+                    } label: {
+                        VStack(alignment: .leading) {
+                            Text(p.momName).font(.headline)
+                            Text("\(p.numberOfChildren) children • \(p.activityLevel)")
+                                .foregroundStyle(.secondary)
+                        }
                     }
+                    .buttonStyle(.plain)
                 }
                 .onDelete { idx in
                     for i in idx { context.delete(profiles[i]) }

--- a/LatchFitTests/LatchFitTests.swift
+++ b/LatchFitTests/LatchFitTests.swift
@@ -15,10 +15,8 @@ struct LatchFitTests {
     }
 
     @Test func onboardingLogic() throws {
-        #expect(needsOnboarding(profileCount: 0, hasCompletedOnboarding: false))
-        #expect(needsOnboarding(profileCount: 0, hasCompletedOnboarding: true))
-        #expect(needsOnboarding(profileCount: 1, hasCompletedOnboarding: false))
-        #expect(!needsOnboarding(profileCount: 1, hasCompletedOnboarding: true))
+        #expect(needsOnboarding(profileCount: 0))
+        #expect(!needsOnboarding(profileCount: 1))
     }
 
 }


### PR DESCRIPTION
## Summary
- keep active profile id with a dedicated `ActiveProfileStore`
- wire store through app and profile onboarding so new profiles are selected
- ensure app shows onboarding only when no profiles exist and otherwise prompts to choose an active profile

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -project LatchFit.xcodeproj -scheme LatchFit -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4864a447483328e58dc5960fe0be4