### PR TITLE
Track duration and mode for milk sessions

### DIFF
--- a/LatchFit/Models.swift
+++ b/LatchFit/Models.swift
@@ -94,17 +94,24 @@ final class PumpSession {
     // Persist side as a simple string for schema stability: "left", "right", "both"
     var sideRaw: String
     var note: String?
+    var durationSec: Int?
+    /// "nursing" or "pumping"
+    var mode: String?
 
     init(id: UUID = UUID(),
          date: Date = .now,
          volumeOz: Double,
          sideRaw: String = "both",
-         note: String? = nil) {
+         note: String? = nil,
+         durationSec: Int? = nil,
+         mode: String? = nil) {
         self.id = id
         self.date = date
         self.volumeOz = volumeOz
         self.sideRaw = sideRaw
         self.note = note
+        self.durationSec = durationSec
+        self.mode = mode
     }
 
     // Convenience typed accessor (not persisted)


### PR DESCRIPTION
## Summary
- extend `PumpSession` with optional `durationSec` and `mode`
- record a `PumpSession` when stopping the timer and prompt for pumped ounces when in Pumping mode
- add a mode picker and `Done` keyboard toolbars for volume fields

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ad9e6620833290135251a55e036f