### PR TITLE
feat(baby+milk): restore Baby tab, persist Milk sessions, scope data to active mom; keep onboarding

### DIFF
--- a/LatchFit/LatchFitApp.swift
+++ b/LatchFit/LatchFitApp.swift
@@ -59,6 +59,7 @@ let sharedModelContainer: ModelContainer = {
         WeightEntry.self,
         PumpSession.self,
         DiaperEvent.self,   // Baby tab
+        MilkSession.self,
         MilkBag.self,
         WaterIntake.self
     ])

--- a/LatchFit/Models.swift
+++ b/LatchFit/Models.swift
@@ -141,13 +141,37 @@ final class WaterIntake {
 final class DiaperEvent {
     @Attribute(.unique) var id: UUID
     var time: Date
-    /// "wet" or "dirty"
+    /// "wet", "dirty" or "both"
     var kind: String
+    var mom: MomProfile?
 
-    init(id: UUID = UUID(), time: Date = .now, kind: String) {
+    init(id: UUID = UUID(), time: Date = .now, kind: String, mom: MomProfile? = nil) {
         self.id = id
         self.time = time
         self.kind = kind
+        self.mom = mom
+    }
+}
+
+@Model
+final class MilkSession {
+    @Attribute(.unique) var id: UUID
+    var startedAt: Date
+    var endedAt: Date?
+    /// "nurse" or "pump"
+    var type: String
+    var mom: MomProfile?
+
+    init(id: UUID = UUID(), startedAt: Date = .now, endedAt: Date? = nil, type: String, mom: MomProfile? = nil) {
+        self.id = id
+        self.startedAt = startedAt
+        self.endedAt = endedAt
+        self.type = type
+        self.mom = mom
+    }
+
+    var duration: TimeInterval {
+        (endedAt ?? Date()).timeIntervalSince(startedAt)
     }
 }
 


### PR DESCRIPTION
## Summary
- connect Baby tab to diaper tracker with quick Wet/Dirty/Both logging scoped per mom
- save nursing/pumping timer sessions with start/end times and recent session list
- define MilkSession + DiaperEvent models and include them in SwiftData container

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c4bb51e0d88332998367e82a411d06