### PR TITLE
Fix: correct DiaperEvent initializer order in BabyViews; sweep repo for similar call sites

### DIFF
--- a/LatchFit/BabyViews.swift
+++ b/LatchFit/BabyViews.swift
@@ -158,7 +158,7 @@ struct BabyView: View {
 
     // MARK: Actions
     private func add(kind: String) {
-        let event = DiaperEvent(kind: kind, time: .now, mom: activeMom)
+        let event = DiaperEvent(time: .now, kind: kind, mom: activeMom)
         context.insert(event)
         try? context.save()
 


### PR DESCRIPTION
## Summary
- Correct DiaperEvent initializer parameter order in BabyViews
- Sweep repository for other incorrect DiaperEvent initializer usages

## Testing
- `swiftc -typecheck LatchFit/BabyViews.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68c4bdc2befc8332abfe7fa7a6ec907f