### PR TITLE
Model: add MilkSession for dual left/right timers

### DIFF
--- a/LatchFit/MilkLogView.swift
+++ b/LatchFit/MilkLogView.swift
@@ -85,7 +85,15 @@ struct MilkLogView: View {
         if currentSession == nil {
             let start = Date()
             timerStart = start
-            currentSession = MilkSession(startedAt: start, type: selectedMode == "pumping" ? "pump" : "nurse", mom: activeMom)
+            let side: MilkSession.Side? = {
+                switch selectedSide {
+                case .left: return .left
+                case .right: return .right
+                default: return nil
+                }
+            }()
+            let mode: MilkSession.Mode = selectedMode == "pumping" ? .pump : .nurse
+            currentSession = MilkSession(mom: activeMom, mode: mode, side: side, start: start)
         } else {
             timerStart = Date()
         }
@@ -135,7 +143,7 @@ struct MilkLogView: View {
         }
 
         if var milk = currentSession {
-            milk.endedAt = when
+            milk.end = when
             if milk.mom == nil { milk.mom = activeMom }
             if milk.modelContext == nil { context.insert(milk) }
             try? context.save()


### PR DESCRIPTION
## Summary
- extend MilkSession with mode/side enums, start/end accessors and durationSec
- add convenience initializer and side persistence
- update timer to capture mode/side when starting a session

## Testing
- `swiftc LatchFit/Models.swift -o /tmp/models` *(fails: no such module 'SwiftData')*
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c4c0858ce4833299c29f32b7e1f90d