### PR TITLE
Adopt iOS 17 onChange API and clean up unused vars

### DIFF
--- a/LatchFit/ContentView.swift
+++ b/LatchFit/ContentView.swift
@@ -10,7 +10,7 @@ struct ContentView: View {
     @State private var showProfilePicker = false
 
     var body: some View {
-        ZStack {
+        let base = ZStack {
             if shouldShowOnboarding {
                 OnboardingMomProfileView()
             } else {
@@ -22,8 +22,16 @@ struct ContentView: View {
                 .interactiveDismissDisabled()
         }
         .onAppear { evaluateProfileStatus() }
-        .onChange(of: profiles.count) { _ in evaluateProfileStatus() }
-        .onChange(of: activeProfileStore.activeProfileID) { _ in evaluateProfileStatus() }
+
+        if #available(iOS 17.0, *) {
+            base
+                .onChange(of: profiles.count, initial: false) { _, _ in evaluateProfileStatus() }
+                .onChange(of: activeProfileStore.activeProfileID, initial: false) { _, _ in evaluateProfileStatus() }
+        } else {
+            base
+                .onChange(of: profiles.count) { _ in evaluateProfileStatus() }
+                .onChange(of: activeProfileStore.activeProfileID) { _ in evaluateProfileStatus() }
+        }
     }
 
     private var shouldShowOnboarding: Bool {

--- a/LatchFit/MilkTimerPanels.swift
+++ b/LatchFit/MilkTimerPanels.swift
@@ -159,7 +159,7 @@ struct MilkTimerPanels: View {
     private func logSession(side: MilkSession.Side, start: Date, end: Date) {
         guard let mom = activeMom else { showNoProfileAlert = true; return }
         guard end > start else { return }
-        var session = MilkSession(mom: mom,
+        let session = MilkSession(mom: mom,
                                   mode: selectedMode,
                                   side: side,
                                   start: start,

--- a/LatchFit/Models.swift
+++ b/LatchFit/Models.swift
@@ -297,7 +297,7 @@ enum CoachCalculator {
             }
         }()
 
-        var tdee = bmr * mult + bfAdd
+        let tdee = bmr * mult + bfAdd
 
         // goal adjustment
         let delta: Double = {


### PR DESCRIPTION
## Summary
- Use new iOS 17 `.onChange` API with `initial: false` and compatibility fallback
- Replace unmutated `var` locals with `let` in milk timer and model logic

## Testing
- `xcodebuild -version` *(fails: command not found)*
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c4cb86cefc83328a8785020c077749