### PR TITLE
Add pause/resume support for milk timers

### DIFF
--- a/LatchFit/MilkHelpers.swift
+++ b/LatchFit/MilkHelpers.swift
@@ -8,6 +8,18 @@ public func formatElapsed(_ seconds: Int) -> String {
     return String(format: "%02d:%02d", m, s)
 }
 
+/// Close the last open interval in-place if any.
+public func closeOpenInterval(_ intervals: inout [MilkInterval], at end: Date = .init()) {
+    if let idx = intervals.lastIndex(where: { $0.end == nil }) {
+        intervals[idx].end = end
+    }
+}
+
+/// Append a new open interval starting at `start`.
+public func startNewInterval(_ intervals: inout [MilkInterval], at start: Date = .init()) {
+    intervals.append(MilkInterval(start: start, end: nil))
+}
+
 /// Summarize today's total nursing and pumping durations (in seconds)
 /// for the given mom profile.
 public func todayTotals(for mom: MomProfile?, sessions: [MilkSession], now: Date = Date()) -> (nurse: Int, pump: Int) {

--- a/LatchFit/MilkLogView.swift
+++ b/LatchFit/MilkLogView.swift
@@ -10,7 +10,38 @@ struct MilkLogView: View {
     @Query(sort: [SortDescriptor(\MilkSession.startedAt, order: .reverse)])
     private var allSessions: [MilkSession]
 
+    /// Persist the last selected mode between launches.
+    @AppStorage("MilkTimerMode") private var modeRaw: String = MilkSession.Mode.nurse.rawValue
+    private var modeBinding: Binding<MilkSession.Mode> {
+        Binding(get: { MilkSession.Mode(rawValue: modeRaw) ?? .nurse },
+                set: { modeRaw = $0.rawValue })
+    }
+    private var selectedMode: MilkSession.Mode { MilkSession.Mode(rawValue: modeRaw) ?? .nurse }
+
+    // Timer state for each side
+    struct TimerState {
+        var intervals: [MilkInterval] = []
+        var isRunning = false
+        var isPaused = false
+        var lastStart: Date? = nil
+        var durationSec: Int {
+            let closed = intervals.compactMap { iv -> Int? in
+                guard let end = iv.end else { return nil }
+                return Int(end.timeIntervalSince(iv.start))
+            }.reduce(0, +)
+            if let live = lastStart, isRunning {
+                return closed + Int(Date().timeIntervalSince(live))
+            }
+            return closed
+        }
+    }
+
+    @State private var leftSession = TimerState()
+    @State private var rightSession = TimerState()
     @State private var showCalendar = false
+    @State private var showNoProfileAlert = false
+    @State private var toastText: String? = nil
+    @Environment(\.scenePhase) private var scenePhase
 
     private var activeMom: MomProfile? {
         profiles.first { $0.id.uuidString == activeProfileStore.activeProfileID }
@@ -34,7 +65,13 @@ struct MilkLogView: View {
         NavigationStack {
             ScrollView {
                 VStack(spacing: 24) {
-                    MilkTimerPanels()
+                    MilkTimerPanels(left: $leftSession,
+                                    right: $rightSession,
+                                    mode: modeBinding,
+                                    start: start,
+                                    pause: pause,
+                                    resume: resume,
+                                    stop: stopAndLog)
                     todayList
                 }
                 .padding(.horizontal, 16)
@@ -51,6 +88,124 @@ struct MilkLogView: View {
             .sheet(isPresented: $showCalendar) { MilkMonthView() }
             .background(LF.bg.ignoresSafeArea())
         }
+        .overlay(alignment: .top) {
+            if let toastText {
+                Toast(text: toastText)
+                    .padding(.top, 8)
+                    .transition(.move(edge: .top).combined(with: .opacity))
+            }
+        }
+        .alert("No Active Profile", isPresented: $showNoProfileAlert) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text("Please add or select a profile before logging.")
+        }
+        .onChange(of: scenePhase) { phase in
+            if phase == .background {
+                if leftSession.isRunning { closeOpenInterval(&leftSession.intervals) }
+                if rightSession.isRunning { closeOpenInterval(&rightSession.intervals) }
+            } else if phase == .active {
+                if leftSession.isRunning {
+                    leftSession.lastStart = Date(); startNewInterval(&leftSession.intervals, at: leftSession.lastStart!)
+                }
+                if rightSession.isRunning {
+                    rightSession.lastStart = Date(); startNewInterval(&rightSession.intervals, at: rightSession.lastStart!)
+                }
+            }
+        }
+    }
+
+    // MARK: - Actions
+    private func start(_ side: MilkSession.Side) {
+        guard activeMom != nil else { showNoProfileAlert = true; return }
+        let now = Date()
+        switch side {
+        case .left:
+            guard !leftSession.isRunning else { return }
+            leftSession.isRunning = true
+            leftSession.isPaused = false
+            leftSession.lastStart = now
+            startNewInterval(&leftSession.intervals, at: now)
+        case .right:
+            guard !rightSession.isRunning else { return }
+            rightSession.isRunning = true
+            rightSession.isPaused = false
+            rightSession.lastStart = now
+            startNewInterval(&rightSession.intervals, at: now)
+        }
+    }
+
+    private func pause(_ side: MilkSession.Side) {
+        let now = Date()
+        switch side {
+        case .left:
+            guard leftSession.isRunning, !leftSession.isPaused else { return }
+            leftSession.isPaused = true
+            leftSession.isRunning = false
+            closeOpenInterval(&leftSession.intervals, at: now)
+            leftSession.lastStart = nil
+        case .right:
+            guard rightSession.isRunning, !rightSession.isPaused else { return }
+            rightSession.isPaused = true
+            rightSession.isRunning = false
+            closeOpenInterval(&rightSession.intervals, at: now)
+            rightSession.lastStart = nil
+        }
+    }
+
+    private func resume(_ side: MilkSession.Side) {
+        let now = Date()
+        switch side {
+        case .left:
+            guard leftSession.isPaused else { return }
+            leftSession.isPaused = false
+            leftSession.isRunning = true
+            leftSession.lastStart = now
+            startNewInterval(&leftSession.intervals, at: now)
+        case .right:
+            guard rightSession.isPaused else { return }
+            rightSession.isPaused = false
+            rightSession.isRunning = true
+            rightSession.lastStart = now
+            startNewInterval(&rightSession.intervals, at: now)
+        }
+    }
+
+    private func stopAndLog(_ side: MilkSession.Side) {
+        guard let mom = activeMom else { showNoProfileAlert = true; return }
+        let now = Date()
+        switch side {
+        case .left:
+            closeOpenInterval(&leftSession.intervals, at: now)
+            let snapshot = leftSession.intervals
+            let session = MilkSession(mom: mom,
+                                      mode: selectedMode,
+                                      side: .left,
+                                      intervals: snapshot)
+            context.insert(session)
+            try? context.save()
+            showToast("Logged Left • \(selectedMode == .nurse ? "Nurse" : "Pump") • \(session.durationSec/60)m • \(timeOnly(now))")
+            leftSession = TimerState()
+        case .right:
+            closeOpenInterval(&rightSession.intervals, at: now)
+            let snapshot = rightSession.intervals
+            let session = MilkSession(mom: mom,
+                                      mode: selectedMode,
+                                      side: .right,
+                                      intervals: snapshot)
+            context.insert(session)
+            try? context.save()
+            showToast("Logged Right • \(selectedMode == .nurse ? "Nurse" : "Pump") • \(session.durationSec/60)m • \(timeOnly(now))")
+            rightSession = TimerState()
+        }
+    }
+
+    private func showToast(_ text: String) {
+        withAnimation { toastText = text }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            withAnimation { toastText = nil }
+        }
+        bump()
     }
 
     // MARK: - Today list

--- a/LatchFit/MilkTimerPanels.swift
+++ b/LatchFit/MilkTimerPanels.swift
@@ -1,106 +1,66 @@
 import SwiftUI
-import SwiftData
 
-/// Timer UI for left and right sides. Each side can run independently and
-/// logs a `MilkSession` when stopped.
+/// Stateless timer panels for left and right sides.
+/// Drives actions in the parent `MilkLogView` via callbacks.
 struct MilkTimerPanels: View {
-    @Environment(\.modelContext) private var context
-    @EnvironmentObject private var activeProfileStore: ActiveProfileStore
-    @Query(sort: [SortDescriptor(\MomProfile.createdAt, order: .reverse)])
-    private var profiles: [MomProfile]
+    @Binding var left: MilkLogView.TimerState
+    @Binding var right: MilkLogView.TimerState
+    @Binding var mode: MilkSession.Mode
+    var start: (MilkSession.Side) -> Void
+    var pause: (MilkSession.Side) -> Void
+    var resume: (MilkSession.Side) -> Void
+    var stop: (MilkSession.Side) -> Void
 
-    /// Persist the last selected mode between launches.
-    @AppStorage("MilkTimerMode") private var modeRaw: String = MilkSession.Mode.nurse.rawValue
-    private var modeBinding: Binding<MilkSession.Mode> {
-        Binding<MilkSession.Mode>(
-            get: { MilkSession.Mode(rawValue: modeRaw) ?? .nurse },
-            set: { modeRaw = $0.rawValue }
-        )
-    }
-    private var selectedMode: MilkSession.Mode {
-        MilkSession.Mode(rawValue: modeRaw) ?? .nurse
-    }
-
-    // Independent timer state for each side
-    @State private var leftRunning = false
-    @State private var rightRunning = false
-    @State private var leftStart: Date? = nil
-    @State private var rightStart: Date? = nil
     @State private var now: Date = Date()
-    @State private var showNoProfileAlert = false
-    @State private var toastText: String? = nil
-
     private var timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
-
-    private var activeMom: MomProfile? {
-        profiles.first { $0.id.uuidString == activeProfileStore.activeProfileID }
-    }
 
     var body: some View {
         VStack(spacing: 16) {
-            Picker("Mode", selection: modeBinding) {
+            Picker("Mode", selection: $mode) {
                 Text("Nurse").tag(MilkSession.Mode.nurse)
                 Text("Pump").tag(MilkSession.Mode.pump)
             }
             .pickerStyle(.segmented)
 
             HStack(spacing: 16) {
-                sidePanel(side: .left,
-                          running: $leftRunning,
-                          start: $leftStart,
-                          elapsed: leftElapsed,
-                          startAction: startLeft,
-                          stopAction: stopLeft)
-                sidePanel(side: .right,
-                          running: $rightRunning,
-                          start: $rightStart,
-                          elapsed: rightElapsed,
-                          startAction: startRight,
-                          stopAction: stopRight)
+                sidePanel(side: .left, session: $left)
+                sidePanel(side: .right, session: $right)
             }
         }
         .onReceive(timer) { date in
             now = date
         }
-        .overlay(alignment: .top) {
-            if let toastText {
-                Toast(text: toastText)
-                    .padding(.top, 8)
-                    .transition(.move(edge: .top).combined(with: .opacity))
-            }
-        }
-        .alert("No Active Profile", isPresented: $showNoProfileAlert) {
-            Button("OK", role: .cancel) { }
-        } message: {
-            Text("Please add or select a profile before logging.")
-        }
     }
 
-    // MARK: - Panels
     @ViewBuilder
-    private func sidePanel(side: MilkSession.Side,
-                           running: Binding<Bool>,
-                           start: Binding<Date?>,
-                           elapsed: TimeInterval,
-                           startAction: @escaping () -> Void,
-                           stopAction: @escaping () -> Void) -> some View {
+    private func sidePanel(side: MilkSession.Side, session: Binding<MilkLogView.TimerState>) -> some View {
         VStack(spacing: 12) {
             Text(side == .left ? "Left" : "Right")
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
 
-            Text(formatElapsed(Int(elapsed)))
+            Text(formatElapsed(session.wrappedValue.durationSec))
                 .font(.system(size: 40, weight: .semibold, design: .rounded))
                 .monospacedDigit()
 
-            Button {
-                running.wrappedValue ? stopAction() : startAction()
-            } label: {
-                Label(running.wrappedValue ? "Stop" : "Start",
-                      systemImage: running.wrappedValue ? "stop.fill" : "play.fill")
-                    .frame(minWidth: 80)
+            if session.wrappedValue.isRunning {
+                HStack(spacing: 8) {
+                    Button("Pause") { pause(side) }
+                        .buttonStyle(.borderedProminent)
+                    Button("Stop") { stop(side) }
+                        .buttonStyle(.bordered)
+                }
+            } else if session.wrappedValue.isPaused {
+                HStack(spacing: 8) {
+                    Button("Resume") { resume(side) }
+                        .buttonStyle(.borderedProminent)
+                    Button("Stop") { stop(side) }
+                        .buttonStyle(.bordered)
+                }
+            } else {
+                Button("Start") { start(side) }
+                    .buttonStyle(.borderedProminent)
             }
-            .buttonStyle(.borderedProminent)
         }
         .padding(16)
         .frame(maxWidth: .infinity)
@@ -109,78 +69,15 @@ struct MilkTimerPanels: View {
                 .fill(.ultraThinMaterial)
         )
     }
-
-    // MARK: - Elapsed helpers
-    private var leftElapsed: TimeInterval {
-        guard leftRunning, let start = leftStart else { return 0 }
-        return now.timeIntervalSince(start)
-    }
-
-    private var rightElapsed: TimeInterval {
-        guard rightRunning, let start = rightStart else { return 0 }
-        return now.timeIntervalSince(start)
-    }
-
-    // MARK: - Actions
-    private func startLeft() {
-        if leftRunning {
-            stopLeft()
-            return
-        }
-        guard activeMom != nil else { showNoProfileAlert = true; return }
-        leftStart = Date()
-        leftRunning = true
-    }
-    private func startRight() {
-        if rightRunning {
-            stopRight()
-            return
-        }
-        guard activeMom != nil else { showNoProfileAlert = true; return }
-        rightStart = Date()
-        rightRunning = true
-    }
-
-    private func stopLeft() {
-        guard leftRunning, let start = leftStart else { return }
-        let end = Date()
-        logSession(side: .left, start: start, end: end)
-        leftRunning = false
-        leftStart = nil
-    }
-    private func stopRight() {
-        guard rightRunning, let start = rightStart else { return }
-        let end = Date()
-        logSession(side: .right, start: start, end: end)
-        rightRunning = false
-        rightStart = nil
-    }
-
-    private func logSession(side: MilkSession.Side, start: Date, end: Date) {
-        guard let mom = activeMom else { showNoProfileAlert = true; return }
-        guard end > start else { return }
-        let session = MilkSession(mom: mom,
-                                  mode: selectedMode,
-                                  side: side,
-                                  start: start,
-                                  end: end)
-        context.insert(session)
-        try? context.save()
-        let mins = session.durationSec / 60
-        showToast("Logged \(side == .left ? "Left" : "Right") • \(selectedMode == .nurse ? "Nurse" : "Pump") • \(mins)m")
-    }
-
-    private func showToast(_ text: String) {
-        withAnimation { toastText = text }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-            withAnimation { toastText = nil }
-        }
-        bump()
-    }
 }
 
-// Minimal preview for SwiftUI canvas
 #Preview {
-    MilkTimerPanels()
-        .environmentObject(ActiveProfileStore())
+    MilkTimerPanels(left: .constant(MilkLogView.TimerState()),
+                    right: .constant(MilkLogView.TimerState()),
+                    mode: .constant(.nurse),
+                    start: { _ in },
+                    pause: { _ in },
+                    resume: { _ in },
+                    stop: { _ in })
 }
+


### PR DESCRIPTION
## Summary
- support pausable milk sessions with interval tracking and duration computation
- add helper utilities for starting and closing intervals
- update milk log and timer panels with start/pause/resume/stop controls and toast logging

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -scheme LatchFit -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c4db34585c833286bcb25d7612a560