### PR TITLE
Add nutrition models and offline food provider

### DIFF
--- a/LatchFit/LatchFitApp.swift
+++ b/LatchFit/LatchFitApp.swift
@@ -61,7 +61,11 @@ let sharedModelContainer: ModelContainer = {
         DiaperEvent.self,   // Baby tab
         MilkSession.self,
         MilkBag.self,
-        WaterIntake.self
+        WaterIntake.self,
+        Food.self,
+        PantryItem.self,
+        MealItem.self,
+        DayNutritionLog.self
     ])
 
     // Persistent on-disk store

--- a/LatchFit/NutritionModels.swift
+++ b/LatchFit/NutritionModels.swift
@@ -1,0 +1,72 @@
+import Foundation
+import SwiftData
+
+@Model
+struct Food {
+    @Attribute(.unique) var id: UUID
+    var name: String
+    var brand: String?
+    var fdcId: Int64?
+    var portionTypeRaw: String
+
+    init(id: UUID = UUID(), name: String, brand: String? = nil, fdcId: Int64? = nil, portionType: PortionType = .per100g) {
+        self.id = id
+        self.name = name
+        self.brand = brand
+        self.fdcId = fdcId
+        self.portionTypeRaw = portionType.rawValue
+    }
+
+    var portionType: PortionType {
+        get { PortionType(rawValue: portionTypeRaw) ?? .per100g }
+        set { portionTypeRaw = newValue.rawValue }
+    }
+}
+
+struct Nutrients: Codable, Hashable {
+    var calories: Double
+    var protein: Double
+    var carbs: Double
+    var fat: Double
+    var fiber: Double
+    var sugar: Double
+    var sodium: Double
+
+    static var zero: Nutrients { .init(calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0, sugar: 0, sodium: 0) }
+}
+
+enum PortionType: String, Codable {
+    case per100g
+    case perServing
+}
+
+struct FoodPortion: Codable, Hashable {
+    var grams: Double?
+    var quantity: Double
+    var unit: String
+}
+
+@Model
+struct PantryItem {
+    @Attribute(.unique) var id: UUID
+    var food: Food
+    var quantity: Double
+    var unit: String
+}
+
+@Model
+struct MealItem {
+    @Attribute(.unique) var id: UUID
+    var date: Date
+    var food: Food
+    var quantity: Double
+    var unit: String
+    var nutrients: Nutrients
+}
+
+@Model
+struct DayNutritionLog {
+    @Attribute(.unique) var id: UUID
+    var date: Date
+    var totals: Nutrients
+}

--- a/LatchFit/NutritionProviders.swift
+++ b/LatchFit/NutritionProviders.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+protocol NutritionProvider {
+    func searchFoods(query: String, page: Int) async throws -> [Food]
+    func fetchDetails(fdcId: Int64) async throws -> (Food, [FoodPortion], Nutrients)
+}
+
+struct FoodDataCentralProvider: NutritionProvider {
+    let apiKey: String
+    let session: URLSession = .shared
+
+    func searchFoods(query: String, page: Int = 1) async throws -> [Food] {
+        var comps = URLComponents(string: "https://api.nal.usda.gov/fdc/v1/foods/search")!
+        comps.queryItems = [
+            .init(name: "api_key", value: apiKey),
+            .init(name: "query", value: query),
+            .init(name: "pageNumber", value: String(page))
+        ]
+        let (data, _) = try await session.data(from: comps.url!)
+        let decoded = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let foods = (decoded?["foods"] as? [[String: Any]] ?? []).compactMap { item -> Food? in
+            guard let description = item["description"] as? String, let fdcId = item["fdcId"] as? Int64 else { return nil }
+            let brand = item["brandOwner"] as? String
+            return Food(name: description, brand: brand, fdcId: fdcId)
+        }
+        return foods
+    }
+
+    func fetchDetails(fdcId: Int64) async throws -> (Food, [FoodPortion], Nutrients) {
+        var comps = URLComponents(string: "https://api.nal.usda.gov/fdc/v1/food/\(fdcId)")!
+        comps.queryItems = [.init(name: "api_key", value: apiKey)]
+        let (data, _) = try await session.data(from: comps.url!)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let description = json?["description"] as? String ?? ""
+        let brand = json?["brandOwner"] as? String
+        let food = Food(name: description, brand: brand, fdcId: fdcId)
+        let nutrientsArray = json?["labelNutrients"] as? [String: Any] ?? [:]
+        let nutrients = Nutrients(
+            calories: (nutrientsArray["calories"] as? [String: Any])?["value"] as? Double ?? 0,
+            protein: (nutrientsArray["protein"] as? [String: Any])?["value"] as? Double ?? 0,
+            carbs: (nutrientsArray["carbohydrates"] as? [String: Any])?["value"] as? Double ?? 0,
+            fat: (nutrientsArray["fat"] as? [String: Any])?["value"] as? Double ?? 0,
+            fiber: (nutrientsArray["fiber"] as? [String: Any])?["value"] as? Double ?? 0,
+            sugar: (nutrientsArray["sugars"] as? [String: Any])?["value"] as? Double ?? 0,
+            sodium: (nutrientsArray["sodium"] as? [String: Any])?["value"] as? Double ?? 0
+        )
+        let portions: [FoodPortion] = []
+        return (food, portions, nutrients)
+    }
+}
+
+struct LocalFoodProvider: NutritionProvider {
+    let foods: [Food]
+    let portionsMap: [UUID: [FoodPortion]]
+    let nutrientsMap: [UUID: Nutrients]
+
+    init() {
+        let url = Bundle.main.url(forResource: "foods_min", withExtension: "json")!
+        let data = try! Data(contentsOf: url)
+        let items = try! JSONDecoder().decode([LocalFoodItem].self, from: data)
+        var f: [Food] = []
+        var p: [UUID: [FoodPortion]] = [:]
+        var n: [UUID: Nutrients] = [:]
+        for item in items {
+            let food = Food(name: item.name, brand: item.brand, fdcId: item.fdcId, portionType: item.portionType)
+            f.append(food)
+            p[food.id] = item.portions
+            n[food.id] = item.nutrients
+        }
+        self.foods = f
+        self.portionsMap = p
+        self.nutrientsMap = n
+    }
+
+    func searchFoods(query: String, page: Int = 1) async throws -> [Food] {
+        let lower = query.lowercased()
+        return foods.filter { $0.name.lowercased().contains(lower) }
+    }
+
+    func fetchDetails(fdcId: Int64) async throws -> (Food, [FoodPortion], Nutrients) {
+        throw NSError(domain: "LocalFoodProvider", code: 0, userInfo: [NSLocalizedDescriptionKey: "Not supported"])
+    }
+
+    func fetchDetails(foodId: UUID) -> (Food, [FoodPortion], Nutrients)? {
+        guard let food = foods.first(where: { $0.id == foodId }), let portions = portionsMap[foodId], let nutrients = nutrientsMap[foodId] else { return nil }
+        return (food, portions, nutrients)
+    }
+
+    private struct LocalFoodItem: Codable {
+        var name: String
+        var brand: String?
+        var fdcId: Int64?
+        var portionType: PortionType
+        var nutrients: Nutrients
+        var portions: [FoodPortion]
+    }
+}

--- a/LatchFit/NutritionService.swift
+++ b/LatchFit/NutritionService.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+@MainActor
+class NutritionService {
+    static let shared = NutritionService()
+
+    private let provider: NutritionProvider
+
+    init(provider: NutritionProvider? = nil) {
+        if let provider = provider {
+            self.provider = provider
+        } else if let apiKey = ProcessInfo.processInfo.environment["FDC_API_KEY"], !apiKey.isEmpty {
+            self.provider = FoodDataCentralProvider(apiKey: apiKey)
+        } else {
+            self.provider = LocalFoodProvider()
+        }
+    }
+
+    func searchFoods(query: String, page: Int = 1) async -> [Food] {
+        do {
+            return try await provider.searchFoods(query: query, page: page)
+        } catch {
+            return []
+        }
+    }
+}

--- a/LatchFit/Resources/foods_min.json
+++ b/LatchFit/Resources/foods_min.json
@@ -1,0 +1,38 @@
+[
+  {
+    "name": "Banana",
+    "brand": null,
+    "fdcId": null,
+    "portionType": "per100g",
+    "nutrients": {
+      "calories": 89,
+      "protein": 1.1,
+      "carbs": 22.8,
+      "fat": 0.3,
+      "fiber": 2.6,
+      "sugar": 12.2,
+      "sodium": 1
+    },
+    "portions": [
+      { "grams": 118, "quantity": 1, "unit": "medium banana" }
+    ]
+  },
+  {
+    "name": "Egg",
+    "brand": null,
+    "fdcId": null,
+    "portionType": "per100g",
+    "nutrients": {
+      "calories": 155,
+      "protein": 13,
+      "carbs": 1.1,
+      "fat": 11,
+      "fiber": 0,
+      "sugar": 1.1,
+      "sodium": 124
+    },
+    "portions": [
+      { "grams": 50, "quantity": 1, "unit": "large egg" }
+    ]
+  }
+]

--- a/LatchFitTests/NutritionTests.swift
+++ b/LatchFitTests/NutritionTests.swift
@@ -1,0 +1,10 @@
+import Testing
+@testable import LatchFit
+
+struct NutritionTests {
+    @Test func loadLocalFoods() async throws {
+        let provider = LocalFoodProvider()
+        let foods = try await provider.searchFoods(query: "banana", page: 1)
+        #expect(!foods.isEmpty)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -18,3 +18,16 @@
 📜 License
 
 Choose a license (MIT recommended) — right now the repo has no license.
+
+## Nutrition DB setup
+
+The nutrition features can use the USDA FoodData Central API when an API key is available.
+
+1. Sign up for an API key at https://fdc.nal.usda.gov/api-key-signup.html
+2. Add the key to your environment as `FDC_API_KEY`.
+   - In Codex, set it under project **Secrets**.
+   - Locally, you can export it in your shell before running the app:
+     ```bash
+     export FDC_API_KEY=your_key_here
+     ```
+3. If no key is provided, the app falls back to a bundled offline database (`foods_min.json`).


### PR DESCRIPTION
## Summary
- add initial SwiftData models for foods, pantry items, meal logs and daily totals
- implement basic nutrition providers with FoodData Central API and local JSON fallback
- stub nutrition service selecting provider based on `FDC_API_KEY`
- seed offline database with example foods
- document API key setup

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c5003ee4ec8332abfb02313de489de