### PR TITLE
Expose preview TimerState for MilkTimerPanels previews

### DIFF
--- a/LatchFit/MilkLogView.swift
+++ b/LatchFit/MilkLogView.swift
@@ -253,10 +253,24 @@ struct MilkLogView: View {
         return String(format: "%dm %02ds", m, s)
     }
 
-    private func timeOnly(_ d: Date) -> String {
-        let f = DateFormatter(); f.timeStyle = .short; return f.string(from: d)
-    }
+  private func timeOnly(_ d: Date) -> String {
+      let f = DateFormatter(); f.timeStyle = .short; return f.string(from: d)
+  }
 }
+
+#if DEBUG
+extension MilkLogView.TimerState {
+    /// Non-persisted, safe value for SwiftUI previews.
+    static let preview: MilkLogView.TimerState = {
+        MilkLogView.TimerState(
+            intervals: [],
+            isRunning: false,
+            isPaused: false,
+            lastStart: nil
+        )
+    }()
+}
+#endif
 
 #Preview {
     MilkLogView()

--- a/LatchFit/MilkTimerPanels.swift
+++ b/LatchFit/MilkTimerPanels.swift
@@ -74,13 +74,14 @@ struct MilkTimerPanels: View {
     }
 }
 
+#if DEBUG
 #Preview {
-    MilkTimerPanels(left: .constant(MilkLogView.TimerState()),
-                    right: .constant(MilkLogView.TimerState()),
-                    mode: .constant(.nurse),
-                    start: { _ in },
-                    pause: { _ in },
-                    resume: { _ in },
-                    stop: { _ in })
+    MilkTimerPanels(
+        left: .constant(.preview),
+        right: .constant(.preview),
+        mode: .constant(.nurse),
+        start: { _ in }, pause: { _ in }, resume: { _ in }, stop: { _ in }
+    )
 }
+#endif
 


### PR DESCRIPTION
## Summary
- add a DEBUG-only `TimerState.preview` factory
- update `MilkTimerPanels` preview to use new factory

## Testing
- `swift build` *(fails: could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c50985acc483329e8fe283dcf4526a