### PR TITLE
Refactor dashboard queries and fix timer panel access

### DIFF
--- a/LatchFit/MilkTimerPanels.swift
+++ b/LatchFit/MilkTimerPanels.swift
@@ -14,6 +14,24 @@ struct MilkTimerPanels: View {
     @State private var now: Date = Date()
     private var timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
 
+    init(
+        left: Binding<MilkLogView.TimerState>,
+        right: Binding<MilkLogView.TimerState>,
+        mode: Binding<MilkSession.Mode>,
+        start: @escaping (MilkSession.Side) -> Void,
+        pause: @escaping (MilkSession.Side) -> Void,
+        resume: @escaping (MilkSession.Side) -> Void,
+        stop: @escaping (MilkSession.Side) -> Void
+    ) {
+        _left = left
+        _right = right
+        _mode = mode
+        self.start = start
+        self.pause = pause
+        self.resume = resume
+        self.stop = stop
+    }
+
     var body: some View {
         VStack(spacing: 16) {
             Picker("Mode", selection: $mode) {

--- a/LatchFit/NutritionDashboardView.swift
+++ b/LatchFit/NutritionDashboardView.swift
@@ -3,8 +3,10 @@ import SwiftData
 
 struct NutritionDashboardView: View {
     @Environment(\.modelContext) private var context
-    @Query var todaysMeals: [MealItem]
-    @Query var todaysLog: [DayNutritionLog]
+
+    // Query broadly, filter in memory to avoid compiler predicate stress
+    @Query(sort: \MealItem.date, order: .forward) private var allMeals: [MealItem]
+    @Query private var allLogs: [DayNutritionLog]
 
     // Placeholder: wire real goal/exercise/steps when available
     var baseCalGoal: Double = 2210
@@ -13,93 +15,46 @@ struct NutritionDashboardView: View {
     var stepsGoal: Int = 10000
     var exerciseMinutes: Int = 33
 
-    init() {
-        let start = Calendar.current.startOfDay(for: Date())
-        let mealsPred = #Predicate<MealItem> { $0.date >= start }
-        _todaysMeals = Query(filter: mealsPred, sort: \.date, order: .forward)
+    private var startOfToday: Date { Calendar.current.startOfDay(for: Date()) }
 
-        let logPred = #Predicate<DayNutritionLog> { $0.date == start }
-        _todaysLog = Query(filter: logPred)
+    private var todaysMeals: [MealItem] {
+        allMeals.filter { $0.date >= startOfToday }
+    }
+    private var todayLog: DayNutritionLog? {
+        allLogs.first { Calendar.current.isDate($0.date, inSameDayAs: startOfToday) }
     }
 
-    private var foodToday: Double {
-        todaysMeals.reduce(0) { $0 + $1.calories }
-    }
-
+    private var foodToday: Double { todaysMeals.reduce(0) { $0 + $1.calories } }
     private var consumedNet: Double { max(0, foodToday - exerciseToday) }
     private var remaining: Double { max(0, baseCalGoal - consumedNet) }
-    private var progress: CGFloat {
-        baseCalGoal <= 0 ? 0 : CGFloat(consumedNet / baseCalGoal)
-    }
+    private var progress: CGFloat { baseCalGoal <= 0 ? 0 : CGFloat(consumedNet / baseCalGoal) }
 
     var body: some View {
         NavigationStack {
-            ScrollView {
-                VStack(spacing: 16) {
-                    searchField
-
-                    DashboardCard {
-                        HStack(spacing: 18) {
-                            ZStack {
-                                RingProgressView(progress: progress)
-                                    .frame(width: 140, height: 140)
-                                RingCenterLabel(title: "Remaining",
-                                                valueText: String(Int(remaining)),
-                                                subtitle: "kcal")
-                            }
-                            VStack(alignment: .leading, spacing: 10) {
-                                row(icon: "flag", title: "Base Goal", value: Int(baseCalGoal))
-                                row(icon: "fork.knife", title: "Food", value: Int(foodToday))
-                                row(icon: "flame", title: "Exercise", value: Int(exerciseToday))
-                                Spacer(minLength: 0)
-                            }
-                        }
-                    }
-
-                    HStack(spacing: 12) {
-                        DashboardCard {
-                            VStack(alignment: .leading, spacing: 8) {
-                                Text("Steps").font(.smallLabel).foregroundStyle(.secondary)
-                                Text("\(steps)").font(.title2.weight(.semibold)).foregroundStyle(Color.lfInk)
-                                ProgressView(value: min(1, Double(steps) / Double(max(1, stepsGoal))))
-                                    .tint(.lfSageDeep)
-                            }
-                        }
-                        DashboardCard {
-                            VStack(alignment: .leading, spacing: 8) {
-                                Text("Exercise").font(.smallLabel).foregroundStyle(.secondary)
-                                HStack {
-                                    Image(systemName: "flame.fill").foregroundStyle(.lfAmber)
-                                    Text("\(Int(exerciseToday)) cal").font(.headline).foregroundStyle(Color.lfInk)
-                                }
-                                Text(String(format: "%02d:%02d hr", exerciseMinutes / 60, exerciseMinutes % 60))
-                                    .font(.smallLabel).foregroundStyle(.secondary)
-                            }
-                        }
-                    }
-                }
+            ScrollView { content }
                 .padding(16)
-            }
-            .background(Color.lfCanvasBG)
-            .navigationTitle("Today")
-            .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    Image(systemName: "gearshape").foregroundStyle(Color.lfSageDeep)
+                .background(Color.lfCanvasBG)
+                .navigationTitle("Today")
+                .toolbar {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Image(systemName: "gearshape").foregroundStyle(Color.lfSageDeep)
+                    }
                 }
-            }
-            .toolbarBackground(.visible, for: .navigationBar)
-            .toolbarBackground(Color.lfCanvasBG, for: .navigationBar)
+                .toolbarBackground(.visible, for: .navigationBar)
+                .toolbarBackground(Color.lfCanvasBG, for: .navigationBar)
         }
         .tint(.lfSageDeep)
     }
 
-    private func row(icon: String, title: String, value: Int) -> some View {
-        HStack {
-            Image(systemName: icon).foregroundStyle(.secondary)
-            Text(title).foregroundStyle(.secondary)
-            Spacer()
-            Text("\(value)").foregroundStyle(Color.lfInk)
-        }.font(.smallLabel)
+    private var content: some View {
+        VStack(spacing: 16) {
+            searchField
+            summaryCard()
+            HStack(spacing: 12) {
+                stepsCard()
+                exerciseCard()
+            }
+        }
     }
 
     private var searchField: some View {
@@ -111,5 +66,60 @@ struct NutritionDashboardView: View {
         .padding(.vertical, 12).padding(.horizontal, 14)
         .background(RoundedRectangle(cornerRadius: 14, style: .continuous).fill(Color.lfCardBG))
         .overlay(RoundedRectangle(cornerRadius: 14, style: .continuous).stroke(Color.black.opacity(0.04), lineWidth: 1))
+    }
+
+    private func summaryCard() -> some View {
+        DashboardCard {
+            HStack(spacing: 18) {
+                ZStack {
+                    RingProgressView(progress: progress)
+                        .frame(width: 140, height: 140)
+                    RingCenterLabel(title: "Remaining",
+                                    valueText: String(Int(remaining)),
+                                    subtitle: "kcal")
+                }
+                VStack(alignment: .leading, spacing: 10) {
+                    row(icon: "flag", title: "Base Goal", value: Int(baseCalGoal))
+                    row(icon: "fork.knife", title: "Food", value: Int(foodToday))
+                    row(icon: "flame", title: "Exercise", value: Int(exerciseToday))
+                    Spacer(minLength: 0)
+                }
+            }
+        }
+    }
+
+    private func stepsCard() -> some View {
+        DashboardCard {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Steps").font(.smallLabel).foregroundStyle(.secondary)
+                Text("\(steps)").font(.title2.weight(.semibold)).foregroundStyle(Color.lfInk)
+                ProgressView(value: min(1, Double(steps) / Double(max(1, stepsGoal))))
+                    .tint(.lfSageDeep)
+            }
+        }
+    }
+
+    private func exerciseCard() -> some View {
+        DashboardCard {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Exercise").font(.smallLabel).foregroundStyle(.secondary)
+                HStack {
+                    Image(systemName: "flame.fill").foregroundStyle(.lfAmber)
+                    Text("\(Int(exerciseToday)) cal").font(.headline).foregroundStyle(Color.lfInk)
+                }
+                Text(String(format: "%02d:%02d hr", exerciseMinutes / 60, exerciseMinutes % 60))
+                    .font(.smallLabel).foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private func row(icon: String, title: String, value: Int) -> some View {
+        HStack {
+            Image(systemName: icon).foregroundStyle(.secondary)
+            Text(title).foregroundStyle(.secondary)
+            Spacer()
+            Text("\(value)").foregroundStyle(Color.lfInk)
+        }
+        .font(.smallLabel)
     }
 }


### PR DESCRIPTION
## Summary
- Refactor `NutritionDashboardView` to filter queries in-memory and split UI into smaller views to resolve type-checking issues
- Add explicit initializer to `MilkTimerPanels` to expose bindings and callbacks

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b7d9057083328b463fc6ba0efc86