### PR TITLE
Deduplicate color extension + fix call sites

### DIFF
--- a/LatchFit/Assets.xcassets/lfAmber.colorset/Contents.json
+++ b/LatchFit/Assets.xcassets/lfAmber.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.875",
+          "green": "0.686",
+          "blue": "0.169",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/LatchFit/Assets.xcassets/lfCanvasBG.colorset/Contents.json
+++ b/LatchFit/Assets.xcassets/lfCanvasBG.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "1.000",
+          "green": "1.000",
+          "blue": "1.000",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/LatchFit/Assets.xcassets/lfCardBG.colorset/Contents.json
+++ b/LatchFit/Assets.xcassets/lfCardBG.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.949",
+          "green": "0.949",
+          "blue": "0.969",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/LatchFit/Assets.xcassets/lfSage.colorset/Contents.json
+++ b/LatchFit/Assets.xcassets/lfSage.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.561",
+          "green": "0.682",
+          "blue": "0.620",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/LatchFit/Assets.xcassets/lfSageDark.colorset/Contents.json
+++ b/LatchFit/Assets.xcassets/lfSageDark.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.310",
+          "green": "0.400",
+          "blue": "0.345",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/LatchFit/Assets.xcassets/lfSageDeep.colorset/Contents.json
+++ b/LatchFit/Assets.xcassets/lfSageDeep.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.431",
+          "green": "0.565",
+          "blue": "0.459",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/LatchFit/Assets.xcassets/lfSageLight.colorset/Contents.json
+++ b/LatchFit/Assets.xcassets/lfSageLight.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.788",
+          "green": "0.855",
+          "blue": "0.812",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/LatchFit/Assets.xcassets/lfTextPrimary.colorset/Contents.json
+++ b/LatchFit/Assets.xcassets/lfTextPrimary.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.118",
+          "green": "0.122",
+          "blue": "0.133",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/LatchFit/Assets.xcassets/lfTextSecondary.colorset/Contents.json
+++ b/LatchFit/Assets.xcassets/lfTextSecondary.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.420",
+          "green": "0.447",
+          "blue": "0.502",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/LatchFit/Color+Extensions.swift
+++ b/LatchFit/Color+Extensions.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+// Centralized app palette. These map to Color Assets in the asset catalog.
+extension Color {
+    // Sage Green Palette
+    static var lfSageLight: Color { Color("lfSageLight") }
+    static var lfSage:      Color { Color("lfSage") }
+    static var lfSageDark:  Color { Color("lfSageDark") }
+    static var lfSageDeep:  Color { Color("lfSageDeep") }
+
+    // Accent / Highlight
+    static var lfAmber:     Color { Color("lfAmber") }
+
+    // Neutral Backgrounds
+    static var lfCanvasBG:  Color { Color("lfCanvasBG") }
+    static var lfCardBG:    Color { Color("lfCardBG") }
+
+    // Text Colors
+    static var lfTextPrimary:   Color { Color("lfTextPrimary") }
+    static var lfTextSecondary: Color { Color("lfTextSecondary") }
+}

--- a/LatchFit/ContentView.swift
+++ b/LatchFit/ContentView.swift
@@ -75,6 +75,6 @@ private struct MainTabView: View {
             ProfilesManagerView()
                 .tabItem { Label("Profiles", systemImage: "person.2") }
         }
-        .tint(.lfSageDeep)
+        .tint(Color.lfSageDeep)
     }
 }

--- a/LatchFit/NutritionDashboardView.swift
+++ b/LatchFit/NutritionDashboardView.swift
@@ -43,7 +43,7 @@ struct NutritionDashboardView: View {
                 .toolbarBackground(.visible, for: .navigationBar)
                 .toolbarBackground(Color.lfCanvasBG, for: .navigationBar)
         }
-        .tint(.lfSageDeep)
+        .tint(Color.lfSageDeep)
     }
 
     private var content: some View {
@@ -59,8 +59,8 @@ struct NutritionDashboardView: View {
 
     private var searchField: some View {
         HStack(spacing: 10) {
-            Image(systemName: "magnifyingglass").foregroundStyle(Color.lfMutedText)
-            Text("Search for a food").foregroundStyle(Color.lfMutedText)
+            Image(systemName: "magnifyingglass").foregroundStyle(Color.lfTextSecondary)
+            Text("Search for a food").foregroundStyle(Color.lfTextSecondary)
             Spacer()
         }
         .padding(.vertical, 12).padding(.horizontal, 14)
@@ -92,9 +92,9 @@ struct NutritionDashboardView: View {
         DashboardCard {
             VStack(alignment: .leading, spacing: 8) {
                 Text("Steps").font(.smallLabel).foregroundStyle(.secondary)
-                Text("\(steps)").font(.title2.weight(.semibold)).foregroundStyle(Color.lfInk)
+                Text("\(steps)").font(.title2.weight(.semibold)).foregroundStyle(Color.lfTextPrimary)
                 ProgressView(value: min(1, Double(steps) / Double(max(1, stepsGoal))))
-                    .tint(.lfSageDeep)
+                    .tint(Color.lfSageDeep)
             }
         }
     }
@@ -104,8 +104,8 @@ struct NutritionDashboardView: View {
             VStack(alignment: .leading, spacing: 8) {
                 Text("Exercise").font(.smallLabel).foregroundStyle(.secondary)
                 HStack {
-                    Image(systemName: "flame.fill").foregroundStyle(.lfAmber)
-                    Text("\(Int(exerciseToday)) cal").font(.headline).foregroundStyle(Color.lfInk)
+                    Image(systemName: "flame.fill").foregroundStyle(Color.lfAmber)
+                    Text("\(Int(exerciseToday)) cal").font(.headline).foregroundStyle(Color.lfTextPrimary)
                 }
                 Text(String(format: "%02d:%02d hr", exerciseMinutes / 60, exerciseMinutes % 60))
                     .font(.smallLabel).foregroundStyle(.secondary)
@@ -118,7 +118,7 @@ struct NutritionDashboardView: View {
             Image(systemName: icon).foregroundStyle(.secondary)
             Text(title).foregroundStyle(.secondary)
             Spacer()
-            Text("\(value)").foregroundStyle(Color.lfInk)
+            Text("\(value)").foregroundStyle(Color.lfTextPrimary)
         }
         .font(.smallLabel)
     }

--- a/LatchFit/RingProgressView.swift
+++ b/LatchFit/RingProgressView.swift
@@ -25,9 +25,9 @@ struct RingCenterLabel: View {
 
     var body: some View {
         VStack(spacing: 4) {
-            Text(valueText).font(.ringBig).foregroundStyle(Color.lfInk)
-            Text(title).font(.footnote).foregroundStyle(Color.lfMutedText)
-            if let subtitle { Text(subtitle).font(.smallLabel).foregroundStyle(Color.lfMutedText) }
+            Text(valueText).font(.ringBig).foregroundStyle(Color.lfTextPrimary)
+            Text(title).font(.footnote).foregroundStyle(Color.lfTextSecondary)
+            if let subtitle { Text(subtitle).font(.smallLabel).foregroundStyle(Color.lfTextSecondary) }
         }
     }
 }

--- a/LatchFit/Theme.swift
+++ b/LatchFit/Theme.swift
@@ -1,20 +1,8 @@
 import SwiftUI
 
-extension Color {
-    static let lfSage      = Color(hex: 0x8FAE9E)
-    static let lfSageDeep  = Color(hex: 0x6E9075)
-    static let lfSageLight = Color(hex: 0xC9DACF)
-    static let lfLeaf      = Color(hex: 0x98C1A2)
-    static let lfAmber     = Color(hex: 0xDFAF2B)
-    static let lfInk       = Color(hex: 0x1E1F22)
-    static let lfMutedText = Color(hex: 0x6B7280)
-    static let lfCardBG    = Color(uiColor: .secondarySystemBackground)
-    static let lfCanvasBG  = Color(uiColor: .systemBackground)
-}
-
 extension LinearGradient {
     static var lfRing: LinearGradient {
-        LinearGradient(colors: [.lfSageDeep, .lfSage, .lfLeaf],
+        LinearGradient(colors: [.lfSageDeep, .lfSage, .lfSageLight],
                        startPoint: .topLeading,
                        endPoint: .bottomTrailing)
     }


### PR DESCRIPTION
## Summary
- centralize color definitions into `Color+Extensions` with computed properties backed by asset colors
- remove old Color extension and adjust ring gradient
- update views to reference `Color.lf*` and switch to new text colors
- add missing color assets for palette

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5bc25877c8332a3aee450baf2e0ad