### PR TITLE
Fix Nutrition dashboard and color palette

### DIFF
--- a/LatchFit/Color+Extensions.swift
+++ b/LatchFit/Color+Extensions.swift
@@ -1,21 +1,25 @@
 import SwiftUI
 
-// Centralized app palette. These map to Color Assets in the asset catalog.
-extension Color {
-    // Sage Green Palette
-    static var lfSageLight: Color { Color("lfSageLight") }
-    static var lfSage:      Color { Color("lfSage") }
-    static var lfSageDark:  Color { Color("lfSageDark") }
-    static var lfSageDeep:  Color { Color("lfSageDeep") }
+// Centralized app palette (Sage theme)
+public extension Color {
+    // Sage family
+    static let lfSageLight = Color("lfSageLight")
+    static let lfSage      = Color("lfSage")
+    static let lfSageDark  = Color("lfSageDark")
+    static let lfSageDeep  = Color("lfSageDeep")
 
-    // Accent / Highlight
-    static var lfAmber:     Color { Color("lfAmber") }
+    // Accent
+    static let lfAmber     = Color("lfAmber")
 
-    // Neutral Backgrounds
-    static var lfCanvasBG:  Color { Color("lfCanvasBG") }
-    static var lfCardBG:    Color { Color("lfCardBG") }
+    // Backgrounds
+    static let lfCanvasBG  = Color("lfCanvasBG")
+    static let lfCardBG    = Color("lfCardBG")
 
-    // Text Colors
-    static var lfTextPrimary:   Color { Color("lfTextPrimary") }
-    static var lfTextSecondary: Color { Color("lfTextSecondary") }
+    // Text system
+    static let lfTextPrimary   = Color("lfTextPrimary")
+    static let lfTextSecondary = Color("lfTextSecondary")
+
+    // Convenience text colors that must remain true Color (NOT views)
+    static let lfInk        = Color(.label)
+    static let lfMutedText  = Color(.secondaryLabel)
 }

--- a/LatchFit/NutritionDashboardView.swift
+++ b/LatchFit/NutritionDashboardView.swift
@@ -31,13 +31,13 @@ struct NutritionDashboardView: View {
 
     var body: some View {
         NavigationStack {
-            ScrollView { content }
+            ScrollView(.vertical, showsIndicators: false) { content }
                 .padding(16)
                 .background(Color.lfCanvasBG)
                 .navigationTitle("Today")
                 .toolbar {
                     ToolbarItem(placement: .topBarTrailing) {
-                        Image(systemName: "gearshape").foregroundStyle(Color.lfSageDeep)
+            Image(systemName: "gearshape").foregroundStyle(Color.lfSageDeep)
                     }
                 }
                 .toolbarBackground(.visible, for: .navigationBar)
@@ -59,8 +59,8 @@ struct NutritionDashboardView: View {
 
     private var searchField: some View {
         HStack(spacing: 10) {
-            Image(systemName: "magnifyingglass").foregroundStyle(Color.lfTextSecondary)
-            Text("Search for a food").foregroundStyle(Color.lfTextSecondary)
+            Image(systemName: "magnifyingglass").foregroundStyle(Color.lfMutedText)
+            Text("Search for a food").foregroundStyle(Color.lfMutedText)
             Spacer()
         }
         .padding(.vertical, 12).padding(.horizontal, 14)
@@ -92,7 +92,7 @@ struct NutritionDashboardView: View {
         DashboardCard {
             VStack(alignment: .leading, spacing: 8) {
                 Text("Steps").font(.smallLabel).foregroundStyle(.secondary)
-                Text("\(steps)").font(.title2.weight(.semibold)).foregroundStyle(Color.lfTextPrimary)
+                Text("\(steps)").font(.title2.weight(.semibold)).foregroundStyle(Color.lfInk)
                 ProgressView(value: min(1, Double(steps) / Double(max(1, stepsGoal))))
                     .tint(Color.lfSageDeep)
             }

--- a/LatchFit/RingProgressView.swift
+++ b/LatchFit/RingProgressView.swift
@@ -1,33 +1,49 @@
 import SwiftUI
 
-struct RingProgressView: View {
-    var progress: CGFloat
-    var lineWidth: CGFloat = 14
-    var showShadow = true
+public struct RingProgressView: View {
+    public var progress: CGFloat           // 0…1
 
-    var body: some View {
+    public init(progress: CGFloat) {
+        self.progress = progress
+    }
+
+    public var body: some View {
         ZStack {
-            Circle().stroke(Color.lfSageLight.opacity(0.35), lineWidth: lineWidth)
             Circle()
-                .trim(from: 0, to: max(0, min(progress, 1)))
-                .stroke(LinearGradient.lfRing, style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
+                .stroke(Color.lfSageLight, lineWidth: 10)
+
+            Circle()
+                .trim(from: 0, to: max(0, min(1, progress)))
+                .stroke(Color.lfSageDeep, style: StrokeStyle(lineWidth: 10, lineCap: .round))
                 .rotationEffect(.degrees(-90))
-                .shadow(color: showShadow ? .black.opacity(0.1) : .clear, radius: 4, y: 2)
-                .animation(.spring(duration: 0.7, bounce: 0.25), value: progress)
+                .animation(.easeInOut(duration: 0.6), value: progress)
         }
+        .opacity(Double(progress.isFinite ? 1 : 0)) // removes ambiguity
     }
 }
 
-struct RingCenterLabel: View {
-    let title: String
-    let valueText: String
-    let subtitle: String?
+public struct RingCenterLabel: View {
+    public var title: String
+    public var valueText: String
+    public var subtitle: String
 
-    var body: some View {
-        VStack(spacing: 4) {
-            Text(valueText).font(.ringBig).foregroundStyle(Color.lfTextPrimary)
-            Text(title).font(.footnote).foregroundStyle(Color.lfTextSecondary)
-            if let subtitle { Text(subtitle).font(.smallLabel).foregroundStyle(Color.lfTextSecondary) }
+    public init(title: String, valueText: String, subtitle: String) {
+        self.title = title
+        self.valueText = valueText
+        self.subtitle = subtitle
+    }
+
+    public var body: some View {
+        VStack(spacing: 2) {
+            Text(valueText)
+                .font(.system(size: 28, weight: .semibold))
+                .foregroundStyle(Color.lfInk)
+            Text(title)
+                .font(.system(size: 12, weight: .regular))
+                .foregroundStyle(Color.lfMutedText)
+            Text(subtitle)
+                .font(.system(size: 11, weight: .regular))
+                .foregroundStyle(Color.lfMutedText)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Centralize app palette in `Color+Extensions` with new ink and muted text colors
- Resolve ambiguous ScrollView and color usage in `NutritionDashboardView`
- Make `RingProgressView` fonts and opacity explicit

## Testing
- `xcodebuild -project LatchFit.xcodeproj -scheme LatchFit -destination 'platform=iOS Simulator,name=iPhone 16 Pro' build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5bf44a328833281b0af987af146e2