### PR TITLE
Fix color helper duplication and toolbar ambiguity

### DIFF
--- a/LatchFit/NutritionDashboardView.swift
+++ b/LatchFit/NutritionDashboardView.swift
@@ -40,7 +40,8 @@ struct NutritionDashboardView: View {
         }
         .toolbar(content: {
             ToolbarItem(placement: .topBarTrailing) {
-                Image(systemName: "gearshape").foregroundStyle(Color.lfSageDeep)
+                Image(systemName: "gearshape")
+                    .foregroundStyle(Color.lfSageDeep)
             }
         })
         .toolbarBackground(.visible, for: .navigationBar)

--- a/LatchFit/SharedUI/DashboardCard.swift
+++ b/LatchFit/SharedUI/DashboardCard.swift
@@ -11,7 +11,10 @@ struct DashboardCard<Content: View>: View {
             )
             .overlay(
                 RoundedRectangle(cornerRadius: 16, style: .continuous)
-                    .stroke(SwiftUI.Color.black.opacity(0.04), lineWidth: 1)
+                    .stroke(
+                        SwiftUI.Color.black.opacity(0.04),
+                        lineWidth: 1
+                    )
             )
     }
 }

--- a/LatchFit/Theme.swift
+++ b/LatchFit/Theme.swift
@@ -6,16 +6,6 @@ extension LinearGradient {
                        startPoint: .topLeading,
                        endPoint: .bottomTrailing)
     }
-}
-
-extension Color {
-    init(hex: UInt, alpha: Double = 1.0) {
-        let r = Double((hex >> 16) & 0xFF) / 255
-        let g = Double((hex >> 8) & 0xFF) / 255
-        let b = Double(hex & 0xFF) / 255
-        self = Color(.sRGB, red: r, green: g, blue: b, opacity: alpha)
-    }
-}
 
 extension Font {
     static var cardTitle: Font { .system(.title3, design: .rounded).weight(.semibold) }


### PR DESCRIPTION
## Summary
- centralize `Color` helpers in `Color+Extensions.swift`
- tidy `NutritionDashboardView` toolbar and color usage
- align dashboard card stroke with qualified `SwiftUI.Color`

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d99e05b8833293a7f9cee2a3078e