### PR TITLE
Fix: deduplicate Color extensions and resolve toolbar/opacity ambiguity.

### DIFF
--- a/LatchFit/ConfettiHelpers.swift
+++ b/LatchFit/ConfettiHelpers.swift
@@ -52,7 +52,7 @@ struct ConfettiView: View {
                     ZStack {
                         ForEach(0..<18, id: \.self) { i in
                             Circle()
-                                .fill(.pink.opacity(0.8))
+                                .fill(SwiftUI.Color.pink.opacity(0.8))
                                 .frame(width: 6, height: 6)
                                 .offset(x: CGFloat.random(in: -120...120),
                                         y: CGFloat.random(in: -60...60))

--- a/LatchFit/ScanViews.swift
+++ b/LatchFit/ScanViews.swift
@@ -12,7 +12,7 @@ struct ScanLabelView: View {
                     .foregroundStyle(.secondary)
                 TextEditor(text: $text)
                     .frame(minHeight: 180)
-                    .overlay(RoundedRectangle(cornerRadius: 12).stroke(.secondary.opacity(0.2)))
+                    .overlay(RoundedRectangle(cornerRadius: 12).stroke(SwiftUI.Color.secondary.opacity(0.2)))
                 Button {
                     // Dummy parse — replace with Vision text detection
                     let cal = 120, protein = 12, fat = 4, carbs = 14
@@ -22,14 +22,14 @@ struct ScanLabelView: View {
                     Text("Parse").frame(maxWidth: .infinity)
                 }.buttonStyle(.borderedProminent)
             }
-            .padding()
-            .navigationTitle("Scan Label")
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("Close") { dismiss() }
-                }
-            }
-        }
-    }
-}
+              .padding()
+              .navigationTitle("Scan Label")
+          }
+          .toolbar {
+              ToolbarItem(placement: .cancellationAction) {
+                  Button("Close") { dismiss() }
+              }
+          }
+      }
+  }
 

--- a/LatchFit/SharedUI.swift
+++ b/LatchFit/SharedUI.swift
@@ -9,7 +9,7 @@ enum LF {
     static let pad: CGFloat = 16
     // Accent palette used across the app
     static let accent = Color.accentColor
-    static let accentSoft = Color.accentColor.opacity(0.12)
+    static let accentSoft = SwiftUI.Color.accentColor.opacity(0.12)
 }
 
 // MARK: - Card + Header


### PR DESCRIPTION
## Summary
- Qualify SwiftUI color usages to avoid opacity ambiguity.
- Move toolbar modifier to NavigationStack level in ScanLabelView.
- Confirm Color+Extensions.swift as the single source of app colors.

## Testing
- `xcodebuild -scheme LatchFit -sdk iphonesimulator build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ec6f70ac8332bdfe940e04606bb9