### PR TITLE
Add JBDatePicker as shared dependency

### DIFF
--- a/LatchFit.xcodeproj/project.pbxproj
+++ b/LatchFit.xcodeproj/project.pbxproj
@@ -7,7 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		88C89E082E708CFE0021F6D4 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 88C89E072E708CFE0021F6D4 /* Lottie */; };
+               88C89E082E708CFE0021F6D4 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 88C89E072E708CFE0021F6D4 /* Lottie */; };
+               FC5EDAD432F6421497CE1980 /* JBDatePicker in Frameworks */ = {isa = PBXBuildFile; productRef = 090D50B82E094497BF898FFD /* JBDatePicker */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -52,14 +53,15 @@
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		882660DC2E6E706D000BCBB0 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				88C89E082E708CFE0021F6D4 /* Lottie in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+                882660DC2E6E706D000BCBB0 /* Frameworks */ = {
+                        isa = PBXFrameworksBuildPhase;
+                        buildActionMask = 2147483647;
+                        files = (
+                               88C89E082E708CFE0021F6D4 /* Lottie in Frameworks */,
+                               FC5EDAD432F6421497CE1980 /* JBDatePicker in Frameworks */,
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
 		882660E92E6E706E000BCBB0 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -124,9 +126,10 @@
 				882660E12E6E706D000BCBB0 /* LatchFit */,
 			);
 			name = LatchFit;
-			packageProductDependencies = (
-				88C89E072E708CFE0021F6D4 /* Lottie */,
-			);
+                       packageProductDependencies = (
+                               88C89E072E708CFE0021F6D4 /* Lottie */,
+                               090D50B82E094497BF898FFD /* JBDatePicker */,
+                       );
 			productName = LatchFit;
 			productReference = 882660DF2E6E706D000BCBB0 /* LatchFit.app */;
 			productType = "com.apple.product-type.application";
@@ -209,9 +212,10 @@
 			);
 			mainGroup = 882660D62E6E706D000BCBB0;
 			minimizedProjectReferenceProxies = 1;
-			packageReferences = (
-				882661092E6FF1C3000BCBB0 /* XCRemoteSwiftPackageReference "lottie-spm" */,
-			);
+                       packageReferences = (
+                               882661092E6FF1C3000BCBB0 /* XCRemoteSwiftPackageReference "lottie-spm" */,
+                               023D9628E2E545A2A758FDDD /* XCRemoteSwiftPackageReference "JBDatePicker" */,
+                       );
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 882660E02E6E706D000BCBB0 /* Products */;
 			projectDirPath = "";
@@ -573,22 +577,35 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		882661092E6FF1C3000BCBB0 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/airbnb/lottie-spm.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 4.5.2;
-			};
-		};
+               882661092E6FF1C3000BCBB0 /* XCRemoteSwiftPackageReference "lottie-spm" */ = {
+                       isa = XCRemoteSwiftPackageReference;
+                       repositoryURL = "https://github.com/airbnb/lottie-spm.git";
+                       requirement = {
+                               kind = upToNextMajorVersion;
+                               minimumVersion = 4.5.2;
+                       };
+               };
+               023D9628E2E545A2A758FDDD /* XCRemoteSwiftPackageReference "JBDatePicker" */ = {
+                       isa = XCRemoteSwiftPackageReference;
+                       repositoryURL = "https://github.com/myfitnesspal/JBDatePicker.git";
+                       requirement = {
+                               kind = exactVersion;
+                               version = 1.2.5;
+                       };
+               };
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		88C89E072E708CFE0021F6D4 /* Lottie */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 882661092E6FF1C3000BCBB0 /* XCRemoteSwiftPackageReference "lottie-spm" */;
-			productName = Lottie;
-		};
+               88C89E072E708CFE0021F6D4 /* Lottie */ = {
+                       isa = XCSwiftPackageProductDependency;
+                       package = 882661092E6FF1C3000BCBB0 /* XCRemoteSwiftPackageReference "lottie-spm" */;
+                       productName = Lottie;
+               };
+               090D50B82E094497BF898FFD /* JBDatePicker */ = {
+                       isa = XCSwiftPackageProductDependency;
+                       package = 023D9628E2E545A2A758FDDD /* XCRemoteSwiftPackageReference "JBDatePicker" */;
+                       productName = JBDatePicker;
+               };
 /* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 882660D72E6E706D000BCBB0 /* Project object */;

--- a/LatchFit/JBDatePickerWrapper.swift
+++ b/LatchFit/JBDatePickerWrapper.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+import JBDatePicker
+
+struct JBDatePickerWrapper: UIViewRepresentable {
+    func makeUIView(context: Context) -> JBDatePickerView {
+        return JBDatePickerView()
+    }
+
+    func updateUIView(_ uiView: JBDatePickerView, context: Context) {}
+}
+

--- a/LatchFit/NutritionDashboardView.swift
+++ b/LatchFit/NutritionDashboardView.swift
@@ -134,3 +134,14 @@ struct NutritionDashboardView: View {
         .font(.footnote)
     }
 }
+
+struct DatePickerDemo: View {
+    var body: some View {
+        VStack {
+            Text("Pick a Date")
+                .font(.headline)
+            JBDatePickerWrapper()
+                .frame(height: 300)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Integrate JBDatePicker via Swift Package Manager
- Provide UIKit-to-SwiftUI wrapper `JBDatePickerWrapper`
- Add sample `DatePickerDemo` view using the new date picker

## Testing
- ⚠️ `xcodebuild -resolvePackageDependencies -project LatchFit.xcodeproj -scheme LatchFit` *(missing: xcodebuild)*
- ⚠️ `xcodebuild -project LatchFit.xcodeproj -scheme LatchFit build` *(missing: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68c7133e7514833290fff97683534bb1